### PR TITLE
Improve `test` and `changelog` workflows triggers

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,6 +2,7 @@ name: Check changelog
 
 on:
   pull_request:
+  workflow_dispatch:
   workflow_call:
     outputs:
       release_type:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,10 +1,6 @@
 name: Check changelog
 
 on:
-  push:
-    branches-ignore:
-      - main
-      - push-action/** # Temporary branches created by CasperWA/push-protected@v2 action on release workflow
   pull_request:
   workflow_call:
     outputs:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,7 +6,6 @@ on:
       - main
       - push-action/** # Temporary branches created by CasperWA/push-protected@v2 action on release workflow
   pull_request:
-    types: [ opened, reopened ]
   workflow_call:
     outputs:
       release_type:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches-ignore:
       - main # tests will be launched by workflow_call from the "Release" workflow
   pull_request:
-    types: [ opened, reopened ]
   workflow_call:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   pull_request:
+  workflow_dispatch:
   workflow_call:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 name: Test
 
 on:
-  push:
-    branches-ignore:
-      - main # tests will be launched by workflow_call from the "Release" workflow
   pull_request:
   workflow_call:
 


### PR DESCRIPTION
This change will :
- Avoid duplicate runs previously initiated by `push` and `pull_request` events
- Ensure test workflow is triggered on updates to pull requests originating from forks
- Enable workflows to be triggered manually to run CI tests on a branch without having to open a pull request