### PR TITLE
Consider EAI_AGAIN errors as a legitimate part of the tracking lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 All changes that impact users of this module are documented in this file, in the [Common Changelog](https://common-changelog.org) format with some additional specifications defined in the CONTRIBUTING file. This codebase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## Unreleased [minor]
+
+_Full changeset and discussions: [#1051](https://github.com/OpenTermsArchive/engine/pull/1051)._
+
+> Development of this release was supported by the [French Ministry for Foreign Affairs](https://www.diplomatie.gouv.fr/fr/politique-etrangere-de-la-france/diplomatie-numerique/) through its ministerial [State Startups incubator](https://beta.gouv.fr/startups/open-terms-archive.html) under the aegis of the Ambassador for Digital Affairs.
+
+### Changed
+
+- Consider EAI_AGAIN errors as a legitimate part of the tracking lifecycle rather than causing the engine to crash
 
 ## 0.34.3 - 2024-02-13
 

--- a/src/archivist/index.js
+++ b/src/archivist/index.js
@@ -154,14 +154,6 @@ export default class Archivist extends events.EventEmitter {
           throw error;
         }
 
-        if (error.message.includes('EAI_AGAIN')) {
-          // EAI_AGAIN is a DNS lookup timed out error, which means it is a network connectivity error or proxy related error.
-          // This operational error is mostly transient and should be handled by retrying the operation.
-          // As there is no retry mechanism in the engine yet, crash the engine and leave it to the process
-          // manager to handle the retries and the delay between them.
-          throw error;
-        }
-
         inaccessibleContentErrors.push(error.message);
       }
     }));


### PR DESCRIPTION
Consider EAI_AGAIN errors as a legitimate part of the tracking lifecycle rather than causing the engine to crash.