### PR TITLE
Minimize required privileges associated to the GitHub token to create issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 All changes that impact users of this module are documented in this file, in the [Common Changelog](https://common-changelog.org) format with some additional specifications defined in the CONTRIBUTING file. This codebase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## Unreleased [minor]
+
+_Full changeset and discussions: [#1054](https://github.com/OpenTermsArchive/engine/pull/1054)._
+
+> Development of this release was supported by the [French Ministry for Foreign Affairs](https://www.diplomatie.gouv.fr/fr/politique-etrangere-de-la-france/diplomatie-numerique/) through its ministerial [State Startups incubator](https://beta.gouv.fr/startups/open-terms-archive.html) under the aegis of the Ambassador for Digital Affairs.
+
+### Changed
+
+- Minimize required privileges associated to the GitHub token to create issues in the declarations repository
 
 ## 0.36.1 - 2024-02-15
 

--- a/src/reporter/github.js
+++ b/src/reporter/github.js
@@ -24,14 +24,6 @@ export default class GitHub {
   }
 
   async initialize() {
-    try {
-      const { data: user } = await this.octokit.request('GET /user', { ...this.commonParams });
-
-      this.authenticatedUserLogin = user.login;
-    } catch (error) {
-      logger.error(`🤖 Could not get authenticated user: ${error}`);
-    }
-
     this.MANAGED_LABELS = require('./labels.json');
 
     const existingLabels = await this.getRepositoryLabels();
@@ -140,7 +132,6 @@ export default class GitHub {
       const issues = await this.octokit.paginate('GET /repos/{owner}/{repo}/issues', {
         ...this.commonParams,
         per_page: 100,
-        creator: this.authenticatedUserLogin,
         ...searchParams,
       }, response => response.data);
 


### PR DESCRIPTION
Enable restricting the scope of the finely-grained GitHub personal access token to the minimum necessary for creating issues. Now, only the `Repository permissions -> Issues` needs to have write access: `Access: Read and write`.

<img width="813" alt="Capture d’écran 2024-02-16 à 17 11 20" src="https://github.com/OpenTermsArchive/engine/assets/1098708/74bf99c0-99d5-4a09-a28b-1405579c70a9">
