### PR TITLE
Improve changelog validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes that impact users of this module are documented in this file, in the [Common Changelog](https://common-changelog.org) format with some additional specifications defined in the CONTRIBUTING file. This codebase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased [no-release]
+
+_Modifications made in this changeset do not add, remove or alter any behavior, dependency, API or functionality of the software. They only change non-functional parts of the repository, such as the README file or CI workflows._
+
 ## 0.37.1 - 2024-02-20
 
 _Full changeset and discussions: [#1056](https://github.com/OpenTermsArchive/engine/pull/1056)._

--- a/scripts/changelog/changelog.js
+++ b/scripts/changelog/changelog.js
@@ -4,6 +4,7 @@ import semver from 'semver';
 import ChangelogValidationError from './changelogValidationError.js';
 
 export default class Changelog {
+  static NO_CODE_CHANGES_REGEX = /^_No code changes were made in this release(.+)_$/m;
   static FUNDER_REGEX = /^> Development of this release was (?:supported|made on a volunteer basis) by (.+)\.$/m;
   static UNRELEASED_REGEX = /## Unreleased[ ]+\[(major|minor|patch)\]/i;
   static CHANGESET_LINK_REGEX = /^_Full changeset and discussions: (.+)._$/m;
@@ -79,7 +80,7 @@ export default class Changelog {
       errors.push(new Error('Missing funder in the "Unreleased" section'));
     }
 
-    if (!unreleased.changes || Array.from(unreleased.changes.values()).every(change => !change.length)) {
+    if (!Changelog.NO_CODE_CHANGES_REGEX.test(unreleased.description) && (!unreleased.changes || Array.from(unreleased.changes.values()).every(change => !change.length))) {
       errors.push(new Error('Missing or malformed changes in the "Unreleased" section'));
     }
 


### PR DESCRIPTION
Enable adding changelog entries without code changes. Particularly valuable for major version releases when the API stability warrants a new release, despite no code modifications, as in https://github.com/OpenTermsArchive/engine/pull/1061.