### PR TITLE
Update types to terms: types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ export default async function track({ services, types, extractOnly, schedule }) 
   }
 
   if (!schedule) {
-    await archivist.track({ services, types });
+    await archivist.track({ services, terms: types });
 
     return;
   }


### PR DESCRIPTION
We found that Archivist expects a variable by the name of 'terms' and not 'types' for the track function.