### PR TITLE
Update Ubuntu on CI test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         operating_system: 
-          - ubuntu-22.04 # Specify latest Ubuntu version with MongoDB preinstalled as for Ubuntu-22.04 MongoDB is not currently available. See https://github.com/actions/runner-images/issues/5490
+          - ubuntu-22.04
           - windows-latest
           - macos-latest
       fail-fast: false # run tests on other operating systems even if one fails
@@ -22,8 +22,6 @@ jobs:
           git config --global core.autocrlf false
       - uses: actions/checkout@v4
       - uses: ankane/setup-mongodb@v1
-        with:
-          mongodb-version: 5.0
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         operating_system: 
-          - ubuntu-20.04 # Specify latest Ubuntu version with MongoDB preinstalled as for Ubuntu-22.04 MongoDB is not currently available. See https://github.com/actions/runner-images/issues/5490
+          - ubuntu-22.04 # Specify latest Ubuntu version with MongoDB preinstalled as for Ubuntu-22.04 MongoDB is not currently available. See https://github.com/actions/runner-images/issues/5490
           - windows-latest
           - macos-latest
       fail-fast: false # run tests on other operating systems even if one fails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes that impact users of this module are documented in this file, in the [Common Changelog](https://common-changelog.org) format with some additional specifications defined in the CONTRIBUTING file. This codebase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased [no-release]
+
+_Modifications made in this changeset do not add, remove or alter any behavior, dependency, API or functionality of the software. They only change non-functional parts of the repository, such as the README file or CI workflows._
+
 ## 5.0.3 - 2025-03-10
 
 _Full changeset and discussions: [#1141](https://github.com/OpenTermsArchive/engine/pull/1141)._


### PR DESCRIPTION
The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025.