### PR TITLE
Support archiving plaintext files/markdown files

### DIFF
--- a/src/archivist/extract/index.js
+++ b/src/archivist/extract/index.js
@@ -35,6 +35,9 @@ export default async function extract(sourceDocument) {
     if (sourceDocument.mimeType == mime.getType('pdf')) {
       return await extractFromPDF(sourceDocument);
     }
+    if (sourceDocument.mimeType == mime.getType('txt') || sourceDocument.mimeType == mime.getType('md')) {
+      return await extractFromMd(sourceDocument);
+    }
 
     return await extractFromHTML(sourceDocument);
   } catch (error) {
@@ -121,6 +124,14 @@ export async function extractFromPDF({ location, content: pdfBuffer }) {
 
   if (!markdownContent) {
     throw new Error(`The PDF file at '${location}' contains no text, it might contain scanned images of text instead of actual text`);
+  }
+
+  return markdownContent;
+}
+
+export async function extractFromMd({ location, content: markdownContent }) {
+  if (!markdownContent) {
+    throw new Error(`The markdown file at '${location}' contains no text`);
   }
 
   return markdownContent;


### PR DESCRIPTION
Hi,

This adds the possibility to archive raw content serve over HTTP (plaintext or markdown). This would typically cover archiving of content served through https://raw.githubusercontent.com.

Best,