### PR TITLE
Add support for extra options in the fullDomFetcher

### DIFF
--- a/src/archivist/fetcher/fullDomFetcher.js
+++ b/src/archivist/fetcher/fullDomFetcher.js
@@ -86,7 +86,21 @@ export async function launchHeadlessBrowser() {
     return browser;
   }
 
-  browser = await puppeteer.launch({ headless: true });
+  const options = {
+    args: [],
+    headless: true,
+  };
+  if (process.env.http_proxy) {
+    options.args = [].concat(options.args, `--proxy-server=${process.env.http_proxy}`);
+  }
+  if (process.env.FETCHER_NO_SANDBOX) {
+    options.args = [].concat(options.args, [ '--no-sandbox', '--disable-setuid-sandbox' ]);
+  }
+  if (process.env.FETCHER_NO_HEADLESS) {
+    options.headless = false;
+  }
+
+  browser = await puppeteer.launch(options);
 
   return browser;
 }


### PR DESCRIPTION
Hey,

This is a follow-up of #1144 as discussed there.

This PR makes the fullDomFetcher configurable through environment variables to support a wider range of setups:
* Add support for proxy
* Sandboxing can be disabled through environment variables (which is required by some Docker setups - e.g. AWS Fargate)
* Disabling headless mode can be done through environment variables (which might be useful for some visual debugging of declarations).

Thanks