### PR TITLE
 Add a horizontal rule to delimit source documents when concatenating them to improve readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All changes that impact users of this module are documented in this file, in the [Common Changelog](https://common-changelog.org) format with some additional specifications defined in the CONTRIBUTING file. This codebase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased [minor]
+
+### Added
+
+- Add a horizontal rule to delimit source documents when concatenating them to improve readability
+
 ## 7.0.0 - 2025-07-21
 
 _Full changeset and discussions: [#1175](https://github.com/OpenTermsArchive/engine/pull/1175)._

--- a/src/archivist/recorder/version.js
+++ b/src/archivist/recorder/version.js
@@ -5,7 +5,7 @@ import Record from './record.js';
 export default class Version extends Record {
   static REQUIRED_PARAMS = Object.freeze([ ...Record.REQUIRED_PARAMS, 'snapshotIds' ]);
 
-  static SOURCE_DOCUMENTS_SEPARATOR = '\n\n';
+  static SOURCE_DOCUMENTS_SEPARATOR = '\n\n- - -\n\n'; // Separator used to delimit source documents when concatenating them. The "- - -" produces a horizontal rule in markdown
 
   constructor(params) {
     super(params);


### PR DESCRIPTION
Fixes #1182.