### PR TITLE
Reduce memory footprint when tracking terms with multiple source documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All changes that impact users of this module are documented in this file, in the
 ### Changed
 
 - Improve memory management when tracking terms with multiple source documents
+- All available snapshots are now stored in multi-documents terms, even if some are unavailable. 
 
 ## 9.0.0 - 2025-09-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All changes that impact users of this module are documented in this file, in the [Common Changelog](https://common-changelog.org) format with some additional specifications defined in the CONTRIBUTING file. This codebase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased [minor]
+
+> Development of this release was supported by the [French Ministry for Foreign Affairs](https://www.diplomatie.gouv.fr/fr/politique-etrangere-de-la-france/diplomatie-numerique/) through its ministerial [State Startups incubator](https://beta.gouv.fr/startups/open-terms-archive.html) under the aegis of the Ambassador for Digital Affairs.
+
+### Changed
+
+- Improve memory management when tracking terms with multiple source documents
+
 ## 9.0.0 - 2025-09-25
 
 _Full changeset and discussions: [#1196](https://github.com/OpenTermsArchive/engine/pull/1196)._

--- a/src/archivist/fetcher/fullDomFetcher.js
+++ b/src/archivist/fetcher/fullDomFetcher.js
@@ -7,7 +7,6 @@ let browser;
 
 export default async function fetch(url, cssSelectors, config) {
   let page;
-  let client;
   let response;
   const selectors = [].concat(cssSelectors);
 
@@ -22,7 +21,7 @@ export default async function fetch(url, cssSelectors, config) {
     await page.setExtraHTTPHeaders({ 'Accept-Language': config.language });
 
     await page.setCacheEnabled(false); // Disable cache to ensure fresh content on each fetch and prevent stale data from previous requests
-    client = await page.target().createCDPSession();
+    const client = await page.target().createCDPSession();
 
     await client.send('Network.clearBrowserCookies'); // Clear cookies to ensure clean state between fetches and prevent session persistence across different URLs
 
@@ -70,15 +69,8 @@ export default async function fetch(url, cssSelectors, config) {
     }
     throw new Error(error.message);
   } finally {
-    // Clean up CDP session first to prevent memory leaks. CDP sessions maintain persistent
-    // connections to Chrome's debugging interface and must be explicitly detached to avoid
-    // keeping references to browser internals that prevent proper garbage collection
-    if (client) {
-      await client.detach().catch(); // Ignore CDP session cleanup errors
-    }
-
     if (page) {
-      await page.close().catch(); // Ignore page close errors
+      await page.close();
     }
   }
 }
@@ -110,38 +102,6 @@ export async function stopHeadlessBrowser() {
     return;
   }
 
-  try {
-    // Close all pages first to ensure clean shutdown. Each page holds significant resources
-    // that must be explicitly released: DOM trees, JavaScript contexts, network connections,
-    // and CDP sessions. Closing pages before browser shutdown prevents race conditions where
-    // the browser terminates while pages are still active, which can lead to memory leaks
-    // and orphaned processes. This defensive approach ensures all page-level resources are
-    // properly cleaned up before browser-level termination.
-    const pages = await browser.pages();
-
-    await Promise.all(pages.map(page => {
-      if (!page.isClosed()) {
-        return page.close().catch(); // Ignore errors when closing individual pages
-      }
-
-      return Promise.resolve(); // Return resolved promise for already closed pages
-    }));
-
-    await browser.close();
-  } catch (error) {
-    console.warn('Error during browser cleanup, attempting force kill:', error);
-
-    // Force kill browser process if normal close fails
-    try {
-      const browserProcess = browser.process();
-
-      if (browserProcess && !browserProcess.killed) {
-        browserProcess.kill('SIGKILL');
-      }
-    } catch (killError) {
-      console.warn('Failed to force kill browser process:', killError);
-    }
-  } finally {
-    browser = null;
-  }
+  await browser.close();
+  browser = null;
 }

--- a/src/archivist/index.test.js
+++ b/src/archivist/index.test.js
@@ -276,8 +276,8 @@ describe('Archivist', function () {
         service: { id: 'test-service' },
         type: 'test-type',
         sourceDocuments: [
-          { location: 'https://example.com/doc1' },
-          { location: 'https://example.com/doc2' },
+          { location: 'https://example.com/doc1', content: 'test', mimeType: 'text/html' },
+          { location: 'https://example.com/doc2', content: 'test', mimeType: 'text/html' },
         ],
       };
     });
@@ -446,7 +446,7 @@ describe('Archivist', function () {
       });
     });
 
-    describe('#recordSnapshots', () => {
+    describe('#recordSnapshot', () => {
       let terms;
       let snapshot;
 
@@ -462,7 +462,7 @@ describe('Archivist', function () {
 
       context('when it is the first record', () => {
         before(async () => {
-          [snapshot] = await app.recordSnapshots(terms);
+          snapshot = await app.recordSnapshot(terms, terms.sourceDocuments[0]);
         });
 
         after(() => {
@@ -483,12 +483,12 @@ describe('Archivist', function () {
           let changedSnapshot;
 
           before(async () => {
-            await app.recordSnapshots(terms);
+            await app.recordSnapshot(terms, terms.sourceDocuments[0]);
             resetSpiesHistory();
             terms.sourceDocuments.forEach(sourceDocument => {
               sourceDocument.content = serviceBSnapshotExpectedContent;
             });
-            [changedSnapshot] = await app.recordSnapshots(terms);
+            changedSnapshot = await app.recordSnapshot(terms, terms.sourceDocuments[0]);
           });
 
           after(() => {
@@ -508,9 +508,9 @@ describe('Archivist', function () {
           let snapshot;
 
           before(async () => {
-            await app.recordSnapshots(terms);
+            await app.recordSnapshot(terms, terms.sourceDocuments[0]);
             resetSpiesHistory();
-            [snapshot] = await app.recordSnapshots(terms);
+            snapshot = await app.recordSnapshot(terms, terms.sourceDocuments[0]);
           });
 
           after(() => {
@@ -544,7 +544,7 @@ describe('Archivist', function () {
 
       context('when it is the first record', () => {
         before(async () => {
-          version = await app.recordVersion(terms);
+          version = await app.recordVersion(terms, 'content');
         });
 
         after(() => {
@@ -565,12 +565,12 @@ describe('Archivist', function () {
           let changedVersion;
 
           before(async () => {
-            await app.recordVersion(terms);
+            await app.recordVersion(terms, 'content');
             resetSpiesHistory();
             terms.sourceDocuments.forEach(sourceDocument => {
               sourceDocument.content = serviceBSnapshotExpectedContent;
             });
-            changedVersion = await app.recordVersion(terms);
+            changedVersion = await app.recordVersion(terms, 'content updated');
           });
 
           after(() => {
@@ -590,9 +590,9 @@ describe('Archivist', function () {
           let version;
 
           before(async () => {
-            await app.recordVersion(terms);
+            await app.recordVersion(terms, 'content');
             resetSpiesHistory();
-            version = await app.recordVersion(terms);
+            version = await app.recordVersion(terms, 'content');
           });
 
           after(() => {

--- a/src/archivist/services/sourceDocument.js
+++ b/src/archivist/services/sourceDocument.js
@@ -35,6 +35,11 @@ export default class SourceDocument {
     return result.filter(selector => selector);
   }
 
+  clearContent() {
+    this.content = null;
+    this.mimeType = null;
+  }
+
   static extractCssSelectorsFromProperty(property) {
     if (Array.isArray(property)) {
       return []


### PR DESCRIPTION
On the VLOPSEs IE server, memory usage is reduced by a factor of 10 when processing combined terms from approximately 50 source documents.