### PR TITLE
Use GitHub link for combine declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 All changes that impact users of this module are documented in this file, in the [Common Changelog](https://common-changelog.org) format with some additional specifications defined in the CONTRIBUTING file. This codebase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased [no-release]
+## Unreleased [patch]
 
-_Modifications made in this changeset do not add, remove or alter any behavior, dependency, API or functionality of the software. They only change non-functional parts of the repository, such as the README file or CI workflows._
+> Development of this release was supported by [User Rights](https://www.user-rights.org).
+
+### Fixed
+
+- Avoid GitHub API "body is too long" error when reporting issues for declarations using `combine`, by linking directly to the declaration file on GitHub instead of embedding the full declaration JSON in the contribution tool URL.
 
 ## 12.0.0 - 2026-05-20
 

--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -137,7 +137,11 @@ No changes were found in the last run, so no new version has been recorded.`,
     });
     const contributionToolUrl = `${CONTRIBUTION_TOOL_URL}?${contributionToolParams}`;
 
-    const latestDeclarationLink = `[Latest declaration](${this.reporter.generateDeclarationURL(terms.service.name)})`;
+    const declarationFileUrl = this.reporter.generateDeclarationURL(terms.service.name);
+    const updateDeclarationLink = terms.hasMultipleSourceDocuments ? `[on GitHub](${declarationFileUrl})` : `[on the contribution tool](${contributionToolUrl})`;
+    const multiDocumentsUpdateInfo = terms.hasMultipleSourceDocuments ? ' (the contribution tool does not support multi-document)' : '';
+
+    const latestDeclarationLink = `[Latest declaration](${declarationFileUrl})`;
     const latestVersionLink = `[Latest version](${this.reporter.generateVersionURL(terms.service.name, terms.type)})`;
     const snapshotsBaseUrl = this.reporter.generateSnapshotsBaseUrl(terms.service.name, terms.type);
     const latestSnapshotsLink = terms.hasMultipleSourceDocuments
@@ -163,13 +167,13 @@ First of all, check if the source documents are accessible through a web browser
 
 #### If the source documents are accessible through a web browser
 
-[Edit the declaration](${contributionToolUrl}):
+Edit the declaration ${updateDeclarationLink}${multiDocumentsUpdateInfo}:
 - Try updating the selectors.
 - Try switching client scripts on with expert mode.
 
 #### If the source documents are not accessible anymore
 
-- If the source documents have moved, find their new location and [update it](${contributionToolUrl}).
+- If the source documents have moved, find their new location and update it ${updateDeclarationLink}.
 - If these terms have been removed, move them from the declaration to its [history file](${DOC_URL}/terms/explanation/declarations-maintenance/#service-history-reference), using \`${validUntil}\` as the \`validUntil\` value.
 - If the service has closed, move the entire contents of the declaration to its [history file](${DOC_URL}/contributing-terms/#service-history), using \`${validUntil}\` as the \`validUntil\` value.
 

--- a/src/reporter/index.test.js
+++ b/src/reporter/index.test.js
@@ -60,4 +60,66 @@ describe('Reporter', () => {
       });
     });
   });
+
+  describe('#generateDescription', () => {
+    const buildReporter = () => new Reporter({
+      type: 'github',
+      repositories: { declarations: 'OpenTermsArchive/test-declarations' },
+    });
+
+    const buildTerms = ({ sourceCount = 1 } = {}) => {
+      const sourceDocuments = Array.from({ length: sourceCount }, (_, index) => ({
+        id: `source-${index}`,
+        location: `https://example.com/source-${index}`,
+        mimeType: 'text/html',
+        snapshotId: `snapshot-${index}`,
+        toPersistence: () => ({ fetch: `https://example.com/source-${index}` }),
+      }));
+
+      return {
+        service: { id: 'TestService', name: 'TestService' },
+        type: 'Terms of Service',
+        sourceDocuments,
+        hasMultipleSourceDocuments: sourceCount > 1,
+        toPersistence: () => ({
+          name: 'TestService',
+          terms: {
+            'Terms of Service': sourceCount > 1
+              ? { combine: sourceDocuments.map(sourceDocument => sourceDocument.toPersistence()) }
+              : sourceDocuments[0].toPersistence(),
+          },
+        }),
+      };
+    };
+
+    const error = { reasons: ['HTTP code 404'] };
+
+    context('when the terms has a single source document', () => {
+      it('deep-links to the contribution tool with the serialized declaration as the edit target', () => {
+        const description = buildReporter().generateDescription({ error, terms: buildTerms({ sourceCount: 1 }) });
+
+        expect(description).to.match(/\(https:\/\/contribute\.opentermsarchive\.org\/[^)]*\bjson=[^)]*\)/);
+      });
+    });
+
+    context('when the terms has multiple source documents (combine)', () => {
+      it('does not deep-link to the contribution tool because it cannot edit multi-source declarations', () => {
+        const description = buildReporter().generateDescription({ error, terms: buildTerms({ sourceCount: 5 }) });
+
+        expect(description).to.not.include('json=');
+      });
+
+      it('links to the declaration file on GitHub as the edit target', () => {
+        const description = buildReporter().generateDescription({ error, terms: buildTerms({ sourceCount: 5 }) });
+
+        expect(description).to.include('github.com/OpenTermsArchive/test-declarations/blob/main/declarations/TestService.json');
+      });
+
+      it('keeps the description below the GitHub 65,536-character issue body limit even with many sources', () => {
+        const description = buildReporter().generateDescription({ error, terms: buildTerms({ sourceCount: 50 }) });
+
+        expect(description.length).to.be.lessThan(65000);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixes the "body is too long" GitHub API error when reporting issues for declarations using `combine`: the contribution tool URL embedded `JSON.stringify(terms.toPersistence())`, which exceeded GitHub's 65,536-character issue body limit.