### PR TITLE
Update markdown cicero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All changes that impact users of this module are documented in this file, in the [Common Changelog](https://common-changelog.org) format with some additional specifications defined in the CONTRIBUTING file. This codebase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased [patch]
+
+> Development of this release was supported by [User Rights](https://www.user-rights.org).
+
+### Fixed
+
+- Update `@accordproject/markdown-cicero` to fix `npm ci` failures in collections caused by broken `file:..` references in the deprecated transitive `@accordproject/concerto-core@3.19.8`
+
 ## 12.0.1 - 2026-05-26
 
 > Development of this release was supported by [User Rights](https://www.user-rights.org).

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@accordproject/concerto-cto": "^3.24.0",
         "@accordproject/concerto-util": "^3.24.0",
-        "@accordproject/markdown-cicero": "^0.16.26",
+        "@accordproject/markdown-cicero": "^0.18.0",
         "@accordproject/markdown-pdf": "^0.16.25",
         "abort-controller": "^3.0.0",
         "ajv": "^8.17.1",
@@ -81,42 +81,71 @@
       }
     },
     "node_modules/@accordproject/concerto-core": {
-      "version": "3.19.8",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.19.8.tgz",
-      "integrity": "sha512-9N3dIKzAgc913Bim3q3E3Ph4LOzDw9+GU2Ut4udjhyLgv5UyMpX+AcfXJ5pMYyXmY9xZv2UtPTdAMYNkVFuJCw==",
-      "deprecated": "This version of the package is deprecated",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.1.3.tgz",
+      "integrity": "sha512-fQj8Q7/jW4XnNI7oz1xZ6BgPVkgZeTVwtkk2+MotWLMX2L8UVn0bMJGR+DBELSyxiTT1f6ELPjU+XclF9bWcUw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@accordproject/concerto-cto": "file:../concerto-cto",
-        "@accordproject/concerto-metamodel": "3.10.2",
-        "@accordproject/concerto-util": "file:../concerto-util",
-        "dayjs": "1.11.10",
-        "debug": "4.3.4",
+        "@accordproject/concerto-cto": "4.1.3",
+        "@accordproject/concerto-metamodel": "^3.13.0",
+        "@accordproject/concerto-util": "4.1.3",
+        "dayjs": "1.11.13",
+        "debug": "4.3.7",
         "lorem-ipsum": "2.0.8",
         "randexp": "0.5.3",
-        "semver": "7.5.4",
-        "slash": "3.0.0",
+        "rfdc": "1.4.1",
+        "semver": "7.6.3",
         "urijs": "1.19.11",
-        "uuid": "9.0.1"
+        "uuid": "11.0.3",
+        "yaml": "^2.8.3"
       },
       "engines": {
         "node": ">=18",
-        "npm": ">=10"
+        "npm": ">=9"
       }
     },
     "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-cto": {
-      "resolved": "node_modules/@accordproject/concerto-cto",
-      "link": true
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.1.3.tgz",
+      "integrity": "sha512-GNQMBwHiubNP1w4u0eE3Zu97fUTQHJ2ahMAj3F3/X7gLPbXGYYFQGag4hk9Z58UW/bRks4cgxtUJsWhaFQrFQw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@accordproject/concerto-metamodel": "^3.13.0",
+        "@accordproject/concerto-util": "4.1.3",
+        "acorn": "^8.15.0",
+        "path-browserify": "^1.0.1",
+        "schema-utils": "^4.3.3"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
     },
     "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-util": {
-      "resolved": "node_modules/@accordproject/concerto-util",
-      "link": true
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.3.tgz",
+      "integrity": "sha512-5Y1fSTqvjB7QOUpy1ivR+Ih7TtrYCGomyrRruWzIP4Xq2he86u2YhKm4aBjrN3SpQRHX6BnGl/GGX0yTTRwVNg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "colors": "1.4.0",
+        "debug": "4.3.4",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
     },
-    "node_modules/@accordproject/concerto-core/node_modules/debug": {
+    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-util/node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -129,37 +158,27 @@
         }
       }
     },
-    "node_modules/@accordproject/concerto-core/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@accordproject/concerto-core/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
-    "node_modules/@accordproject/concerto-core/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+    "node_modules/@accordproject/concerto-core/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "peer": true,
       "bin": {
-        "semver": "bin/semver.js"
+        "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@accordproject/concerto-cto": {
@@ -187,56 +206,15 @@
       }
     },
     "node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.10.2.tgz",
-      "integrity": "sha512-SpCIraVzpCXsaBloGT4BiA2/GTWqXUzk+as1Ac6odUR8pAzkhYc+sXwOgEa9tOQx2heQ+EtamhqqkzDr1jS4rQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.13.1.tgz",
+      "integrity": "sha512-af8mpDuHGSfBH+VlVRwBqhiBVrLI0srRslT44Q4hkZJJHHnxU5K5U2wznGamazP1FMXLnOwXiFG4ZMudAll7Vw==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-util": "3.19.2",
-        "@types/node": "20.7.0"
-      },
+      "peer": true,
       "engines": {
         "node": ">=14",
         "npm": ">=6"
       }
-    },
-    "node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
-      "version": "3.19.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.19.2.tgz",
-      "integrity": "sha512-2N0soMwQCM80wKL7zPENMk55VFdtzUAddIM5W3LdHOPya4SY2GhTz2t0BDMS1I0QFE1tZ33+MjbLWXweN/+2wA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "debug": "4.3.4",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@accordproject/concerto-metamodel/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@accordproject/concerto-metamodel/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "license": "MIT"
     },
     "node_modules/@accordproject/concerto-util": {
       "version": "3.24.0",
@@ -254,14 +232,13 @@
       }
     },
     "node_modules/@accordproject/markdown-cicero": {
-      "version": "0.16.26",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.16.26.tgz",
-      "integrity": "sha512-vGfMMRq8gYGagizDIMAE86ncm/VOX2k7sWFC6VBT2Rs4ekHOtn6GU6xtqTdnuEYU55XgWN7rtaVNGpDu+MC7Qg==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.18.1.tgz",
+      "integrity": "sha512-QhRiYMt7VAs7QLGzVpRSZPa6KNtk12xngO87xRE4kzl34YNG+wPDqsuWhbudD1wouCqkUzjNTBWZocH1KbR7eQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.19.8",
-        "@accordproject/markdown-common": "*",
-        "@accordproject/markdown-it-cicero": "*",
+        "@accordproject/markdown-common": "0.18.1",
+        "@accordproject/markdown-it-cicero": "0.18.1",
         "markdown-it": "^14.1.0",
         "semver": "7.6.3",
         "winston": "3.17.0"
@@ -269,84 +246,40 @@
       "engines": {
         "node": ">=18",
         "npm": ">=9"
+      },
+      "peerDependencies": {
+        "@accordproject/concerto-core": "^4.1.2"
       }
     },
     "node_modules/@accordproject/markdown-common": {
-      "version": "0.16.26",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.16.26.tgz",
-      "integrity": "sha512-yYFxzd/K8CONv4zs4sfSYfTpZR7Vk8XuCfPFJLVEHC/XNuUqyDqMBYvaDHehrlLkQOBHR/vDW4YhzALFXLdRKQ==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.18.1.tgz",
+      "integrity": "sha512-FlfzgdANS4bvCn6DZhM5zT5sOnDG8M5DdFpqH/D1B1oVEdhTkRxtU3iNOi3LsXWR8gl4pAlM+Sj5Ad+3t4o9uw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.19.8",
-        "@xmldom/xmldom": "^0.9.5",
+        "@xmldom/xmldom": "^0.9.10",
         "markdown-it": "^14.1.0"
       },
       "engines": {
         "node": ">=15",
         "npm": ">=9"
+      },
+      "peerDependencies": {
+        "@accordproject/concerto-core": "^4.1.2"
       }
     },
     "node_modules/@accordproject/markdown-it-cicero": {
-      "version": "0.16.25",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-0.16.25.tgz",
-      "integrity": "sha512-8a0vdleXkJpcLdHWRyk73IHms2mrwTZlVqpmOer5HGkYfW1yrmYffnz75bzPWnklbWvlAmRNe3UDwD1P2e3s9Q==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-0.18.1.tgz",
+      "integrity": "sha512-q1/5OsXHCfecpzgKK2IDUYkZsVB9qkaRyvQFcoW+unFTFL0Wjs2Kh8vQ9OvCXuaKXeCz4X73jL7MbuOERu51Ug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "markdown-it": "^13.0.1"
+        "markdown-it": "^14.1.0"
       },
       "engines": {
         "node": ">=18",
         "npm": ">=9"
       }
-    },
-    "node_modules/@accordproject/markdown-it-cicero/node_modules/entities": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/@accordproject/markdown-it-cicero/node_modules/linkify-it": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
-      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^1.0.1"
-      }
-    },
-    "node_modules/@accordproject/markdown-it-cicero/node_modules/markdown-it": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
-      "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "~3.0.1",
-        "linkify-it": "^4.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.js"
-      }
-    },
-    "node_modules/@accordproject/markdown-it-cicero/node_modules/mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-      "license": "MIT"
-    },
-    "node_modules/@accordproject/markdown-it-cicero/node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "license": "MIT"
     },
     "node_modules/@accordproject/markdown-it-template": {
       "version": "0.16.25",
@@ -2344,9 +2277,9 @@
       "license": "ISC"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
-      "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"
@@ -2444,6 +2377,19 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
       }
     },
     "node_modules/ansi-regex": {
@@ -3819,10 +3765,11 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
-      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
-      "license": "MIT"
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.3.7",
@@ -9301,6 +9248,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -9509,6 +9463,44 @@
       },
       "engines": {
         "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/semver": {
@@ -10865,16 +10857,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validator": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@accordproject/concerto-cto": "^3.24.0",
     "@accordproject/concerto-util": "^3.24.0",
-    "@accordproject/markdown-cicero": "^0.16.26",
+    "@accordproject/markdown-cicero": "^0.18.0",
     "@accordproject/markdown-pdf": "^0.16.25",
     "abort-controller": "^3.0.0",
     "ajv": "^8.17.1",


### PR DESCRIPTION
Running `npm ci` in downstream collections now fails — see for example the [user-rights-declarations CI run #26438517995](https://github.com/OpenTermsArchive/user-rights-declarations/actions/runs/26438517995/job/77827350005):

```
npm error Missing: @accordproject/concerto-cto@ from lock file
npm error Missing: @accordproject/concerto-util@ from lock file
```

The engine pulls in a broken `concerto-core` version transitively:

```
@opentermsarchive/engine
└── @accordproject/markdown-cicero@0.16.26
    └── @accordproject/concerto-core@3.19.8   ← broken
```

Upstream published [`concerto-core@3.19.8`](https://www.npmjs.com/package/@accordproject/concerto-core/v/3.19.8) (now flagged as deprecated) with local filesystem paths instead of registry versions in its dependencies:

```json
"@accordproject/concerto-cto": "file:../concerto-cto",
"@accordproject/concerto-util": "file:../concerto-util"
```

The packaging mistake comes from [accordproject/concerto#945](https://github.com/accordproject/concerto/pull/945), which leaked monorepo paths into the published artifact.

The bug has been present since `concerto-core@3.19.8` was released in November 2024 but stayed latent: older `npm` versions silently resolved the `file:..` references via dedup links to the top-level `concerto-cto` and `concerto-util` packages already in the tree. Recent `npm` releases on GitHub Actions runners tightened lock-file validation, and `npm ci` now refuses to proceed.

Bumping `@accordproject/markdown-cicero` to `^0.18.0` removes the problematic branch entirely: from `0.18.0` onwards, this package [no longer declares any `concerto-core` dependency](https://www.npmjs.com/package/@accordproject/markdown-cicero/v/0.18.1?activeTab=dependencies).