### PR TITLE
fix: improve error message for wrongly formatted history files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All changes that impact users of this module are documented in this file, in the [Common Changelog](https://common-changelog.org) format with some additional specifications defined in the CONTRIBUTING file. This codebase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased [patch]
+
+> Development of this release was made on a volunteer basis by Bhavy Singhal.
+
+### Fixed
+- Improve error message when history file is wrongly formatted as an object instead of an array
+
 ## 13.0.0 - 2026-06-22
 
 > Development of this release was supported by [User Rights](https://www.user-rights.org).

--- a/src/archivist/services/index.js
+++ b/src/archivist/services/index.js
@@ -260,6 +260,9 @@ async function loadServiceHistoryFiles(serviceId) {
   ]);
 
   Object.entries(serviceDeclaration.terms).forEach(([ termsType, declaration ]) => {
+    if (!Array.isArray(serviceHistory[termsType]) && serviceHistory[termsType] !== undefined) {
+      throw new Error(`History file for "${termsType}" is not properly formatted: expected an array but got an object. Please use [] instead of {}.`);
+    }
     serviceHistory[termsType] = serviceHistory[termsType] || [];
     serviceHistory[termsType].push(declaration);
   });


### PR DESCRIPTION
Fixes #1184

## What this does
When a history file is formatted incorrectly (using `{}` object instead 
of `[]` array), the engine previously threw a confusing error:
"serviceHistory(termsType) push is not a function"

This change adds a validation check that throws a clear, human-readable 
error message instead, telling the contributor exactly what is wrong and 
how to fix it.

## Why
As reported in issue #1184, this confusing error message caused confusion 
for contributors. A clear error message will help future contributors 
immediately understand and fix their mistake.