### PR TITLE
Randomize tracking

### DIFF
--- a/src/archivist/index.js
+++ b/src/archivist/index.js
@@ -156,6 +156,7 @@ export default class Archivist extends events.EventEmitter {
     this.trackingQueue.concurrency = concurrency;
 
     const tasksToQueue = [];
+
     servicesIds.forEach(serviceId => {
       this.services[serviceId].getTermsTypes().forEach(termsType => {
         if (termsTypes.length && !termsTypes.includes(termsType)) {
@@ -169,7 +170,8 @@ export default class Archivist extends events.EventEmitter {
     const shuffledTasksToQueue = tasksToQueue
       .map(value => ({ value, sort: Math.random() }))
       .sort((a, b) => a.sort - b.sort)
-      .map(({ value }) => value)
+      .map(({ value }) => value);
+
     shuffledTasksToQueue.forEach(task => {
       this.trackingQueue.push(task);
     });

--- a/src/archivist/index.js
+++ b/src/archivist/index.js
@@ -155,14 +155,23 @@ export default class Archivist extends events.EventEmitter {
 
     this.trackingQueue.concurrency = concurrency;
 
+    const tasksToQueue = [];
     servicesIds.forEach(serviceId => {
       this.services[serviceId].getTermsTypes().forEach(termsType => {
         if (termsTypes.length && !termsTypes.includes(termsType)) {
           return;
         }
 
-        this.trackingQueue.push({ terms: this.services[serviceId].getTerms({ type: termsType }), technicalUpgradeOnly });
+        tasksToQueue.push({ terms: this.services[serviceId].getTerms({ type: termsType }), technicalUpgradeOnly });
       });
+    });
+    // Shuffle the tasks not to scrape always in the exact same order, also within a given provider
+    const shuffledTasksToQueue = tasksToQueue
+      .map(value => ({ value, sort: Math.random() }))
+      .sort((a, b) => a.sort - b.sort)
+      .map(({ value }) => value)
+    shuffledTasksToQueue.forEach(task => {
+      this.trackingQueue.push(task);
     });
 
     if (this.trackingQueue.length()) {


### PR DESCRIPTION
Hey,

Here is a small proposal for an addition to shuffle the tasks to be processed for scraping/tracking terms in order to increase stealth and not always hit the same service's pages in the exact same order.

Otherwise, the exact same pattern will happen again and again when scraping a service's terms. This means:
1/ Hitting rate limiting because we are sending a batch (up to MAX_CONCURRENCY) calls more or less the same time to the service.
2/ Easier detection of automated scraping, even more when coupled with a cron-based scheduler, as order of scraping is almost entirely predictible. 

Randomizing the order of tracking of the terms is a cheap solution for this. The only downside might be a slight decrease in readability when ran interactively, but with concurrency enabled this was already the case. If the feature is worth merging, happy to have a better integration with config option or so.

Best,