### PR TITLE
Validate unique combine fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All changes that impact users of this module are documented in this file, in the [Common Changelog](https://common-changelog.org) format with some additional specifications defined in the CONTRIBUTING file. This codebase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased [minor]
+
+> Development of this release was supported by [the Research Chair in Content Moderation](https://regulation-tech.cnam.fr/) at the Conservatoire National des Arts et Métiers.
+
+### Added
+
+- Validate that no `combine` lists the same source document location more than once within a terms type
+
 ## 14.0.0 - 2026-06-23
 
 > Development of this release was supported by [Reset Tech](https://www.reset.tech).

--- a/scripts/declarations/validate/index.mocha.js
+++ b/scripts/declarations/validate/index.mocha.js
@@ -118,6 +118,14 @@ export default async options => {
               describe(type, () => {
                 const terms = service.getTerms({ type });
 
+                if (terms.hasMultipleSourceDocuments) {
+                  it('does not declare the same source document more than once', () => {
+                    const duplicateLocations = [...new Set(terms.duplicateSourceDocuments.map(sourceDocument => sourceDocument.location))];
+
+                    expect(duplicateLocations, `The same source document is declared more than once within the "${type}" combine: ${duplicateLocations.join(', ')}`).to.be.empty;
+                  });
+                }
+
                 terms.sourceDocuments.forEach(sourceDocument => {
                   let filteredContent;
 

--- a/src/archivist/services/terms.js
+++ b/src/archivist/services/terms.js
@@ -13,6 +13,18 @@ export default class Terms {
     return this.sourceDocuments.length > 1;
   }
 
+  get duplicateSourceDocuments() {
+    const seenLocations = new Set();
+
+    return this.sourceDocuments.filter(({ location }) => {
+      const isDuplicate = seenLocations.has(location);
+
+      seenLocations.add(location);
+
+      return isDuplicate;
+    });
+  }
+
   toPersistence() {
     return {
       name: this.service.name,

--- a/src/archivist/services/terms.test.js
+++ b/src/archivist/services/terms.test.js
@@ -80,4 +80,12 @@ describe('Terms', () => {
       expect(result).to.deep.equal(expectedResult);
     });
   });
+
+  describe('#duplicateSourceDocuments', () => {
+    it('returns the source documents that repeat a location', () => {
+      const terms = new Terms({ service, type: termsType, sourceDocuments: [ document1, document2 ] });
+
+      expect(terms.duplicateSourceDocuments).to.deep.equal([document2]);
+    });
+  });
 });


### PR DESCRIPTION
A combine can currently repeat the same fetch URL within a terms type, which causes redundant fetches. `npm run declarations:validate` now rejects it and reports the duplicated URL(s). The same fetch stays allowed across different terms types.