### PR TITLE
Update CI dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node_version }}
-      - run: cd ./demo-declarations && npm install
+      - run: cd ./demo-declarations && npm ci
       - run: npm ci
       - run: ./node_modules/.bin/cross-env NODE_ENV=ci npm run declarations:lint
       - run: ./node_modules/.bin/cross-env NODE_ENV=ci npm run declarations:validate:schema
@@ -106,6 +106,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node_version }}
-      - run: cd ./demo-declarations && npm install
+      - run: cd ./demo-declarations && npm ci
       - run: npm ci
       - run: ./node_modules/.bin/cross-env NODE_ENV=ci npm run metadata:validate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           git config --global core.autocrlf false
       - uses: actions/checkout@v7
       - uses: ankane/setup-mongodb@a01a9a4888b0b7bb1813656d8653fb2b06ae50d8
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node_version }}
       - run: npm ci
@@ -68,7 +68,7 @@ jobs:
         with:
           repository: OpenTermsArchive/demo-declarations
           path: ./demo-declarations
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node_version }}
       - run: cd ./demo-declarations && npm install
@@ -103,7 +103,7 @@ jobs:
         with:
           repository: OpenTermsArchive/demo-declarations
           path: ./demo-declarations
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node_version }}
       - run: cd ./demo-declarations && npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - run: |
           git config --global core.autocrlf false
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ankane/setup-mongodb@a01a9a4888b0b7bb1813656d8653fb2b06ae50d8
       - uses: actions/setup-node@v4
         with:
@@ -63,8 +63,8 @@ jobs:
     steps:
       - run: |
           git config --global core.autocrlf false
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7
         with:
           repository: OpenTermsArchive/demo-declarations
           path: ./demo-declarations
@@ -98,8 +98,8 @@ jobs:
     steps:
       - run: |
           git config --global core.autocrlf false
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7
         with:
           repository: OpenTermsArchive/demo-declarations
           path: ./demo-declarations

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,13 +29,7 @@ jobs:
       - run: |
           git config --global core.autocrlf false
       - uses: actions/checkout@v4
-      # Homebrew refuses formulae from untrusted third-party taps, so trust mongodb/brew before ankane/setup-mongodb installs from it. See https://github.com/ankane/setup-mongodb/issues/7
-      - name: Trust MongoDB Homebrew tap on macOS
-        if: ${{ runner.os == 'macOS' }}
-        run: |
-          brew tap mongodb/brew
-          brew trust mongodb/brew
-      - uses: ankane/setup-mongodb@v1
+      - uses: ankane/setup-mongodb@a01a9a4888b0b7bb1813656d8653fb2b06ae50d8
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes that impact users of this module are documented in this file, in the [Common Changelog](https://common-changelog.org) format with some additional specifications defined in the CONTRIBUTING file. This codebase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased [no-release]
+
+_Modifications made in this changeset do not add, remove or alter any behavior, dependency, API or functionality of the software. They only change non-functional parts of the repository, such as the README file or CI workflows._
+
 ## 14.1.0 - 2026-06-29
 
 > Development of this release was supported by [the Research Chair in Content Moderation](https://regulation-tech.cnam.fr/) at the Conservatoire National des Arts et Métiers.


### PR DESCRIPTION
- Following fix of ankane/setup-mongodb#7, update dependency and erase workaround introduced in #1257.
- Switch to SHA instead of version for third-party dependency.
- Update GitHub-provided actions, trusting GitHub by relying on their version numbers instead of SHA pinning.
- Replace last usages of `npm install` with `npm ci` to accelerate and increase security.