### PR TITLE
Ci speedup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         operating_system: 
-          - ubuntu-22.04
+          - ubuntu-22.04 # Using Ubuntu 22.04 due to AppArmor restrictions in newer versions (23.10+) that interfere with Puppeteer's sandbox functionality. See https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu
           - windows-latest
           - macos-latest
         node_version:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
           - 26
         exclude:
           - operating_system: windows-latest
-            node_version: 26
+            node_version: 22
           - operating_system: macos-latest
-            node_version: 26
+            node_version: 22
       fail-fast: false # run tests on other operating systems even if one fails
 
     runs-on: ${{ matrix.operating_system }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,27 +42,9 @@ jobs:
         run: npm test -- --timeout 5000
 
   validate_declarations:
-    strategy:
-      matrix:
-        operating_system: 
-          - ubuntu-22.04 # Using Ubuntu 22.04 due to AppArmor restrictions in newer versions (23.10+) that interfere with Puppeteer's sandbox functionality. See https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu
-          - windows-latest
-          - macos-latest
-        node_version:
-          - 22
-          - 26
-        exclude:
-          - operating_system: windows-latest
-            node_version: 26
-          - operating_system: macos-latest
-            node_version: 26
-      fail-fast: false # run tests on other operating systems even if one fails
-
-    runs-on: ${{ matrix.operating_system }}
+    runs-on: ubuntu-22.04 # Using Ubuntu 22.04 due to AppArmor restrictions in newer versions (23.10+) that interfere with Puppeteer's sandbox functionality. See https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu
 
     steps:
-      - run: |
-          git config --global core.autocrlf false
       - uses: actions/checkout@v7
       - uses: actions/checkout@v7
         with:
@@ -70,34 +52,16 @@ jobs:
           path: ./demo-declarations
       - uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version: 26
       - run: cd ./demo-declarations && npm ci
       - run: npm ci
       - run: ./node_modules/.bin/cross-env NODE_ENV=ci npm run declarations:lint
       - run: ./node_modules/.bin/cross-env NODE_ENV=ci npm run declarations:validate:schema
 
   validate_metadata:
-    strategy:
-      matrix:
-        operating_system: 
-          - ubuntu-22.04
-          - windows-latest
-          - macos-latest
-        node_version:
-          - 22
-          - 26
-        exclude:
-          - operating_system: windows-latest
-            node_version: 26
-          - operating_system: macos-latest
-            node_version: 26
-      fail-fast: false
-
-    runs-on: ${{ matrix.operating_system }}
+    runs-on: ubuntu-22.04
 
     steps:
-      - run: |
-          git config --global core.autocrlf false
       - uses: actions/checkout@v7
       - uses: actions/checkout@v7
         with:
@@ -105,7 +69,7 @@ jobs:
           path: ./demo-declarations
       - uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version: 26
       - run: cd ./demo-declarations && npm ci
       - run: npm ci
       - run: ./node_modules/.bin/cross-env NODE_ENV=ci npm run metadata:validate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes that impact users of this module are documented in this file, in the [Common Changelog](https://common-changelog.org) format with some additional specifications defined in the CONTRIBUTING file. This codebase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased [no-release]
+
+_Modifications made in this changeset do not add, remove or alter any behavior, dependency, API or functionality of the software. They only change non-functional parts of the repository, such as the README file or CI workflows._
+
 ## 14.1.0 - 2026-06-29
 
 > Development of this release was supported by [the Research Chair in Content Moderation](https://regulation-tech.cnam.fr/) at the Conservatoire National des Arts et Métiers.


### PR DESCRIPTION
Depends on #1258.

### Speedup and failure rate decrease by stopping to run integration tests cross-platform

This changeset stops running metadata and declaration validation on macOS and Windows. This is based on the idea that engine tests definitely should be cross-platform, but smoke-testing downstream dependencies does not need to be cross-platform: cross-platform behavioural consistency is guaranteed by the engine tests, integration testing is not necessary cross-platform. If this hypothesis does not hold in production and we get defect reports, we can revert this changeset.

**Expected speedup: at least 1 minute per run (18% speedup), up to 2m30 (40%) per run.**

Indeed, Windows runs around ~1m15 for both metadata and declarations validation, while macOS and Ubuntu run in around ~42s.
With perfect parallelism, that's 2 x 30s saved; with totally failing parallelism, that's 2 x 75s saved. The reality will probably be somewhere in between.

**Preliminary run result shows no evident speed gain** (5m17s, the lowest in the range of previous runs but still in the same range).

### Test cross-platform on Node latest instead of oldest

For some reason, we were testing on macOS and Windows only on the oldest supported version of Node instead of the most recent. This changeset inverts that behaviour.