### PR TITLE
Add normalize whitespace built-in filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All changes that impact users of this module are documented in this file, in the
 
 ## Unreleased [minor]
 
+> Development of this release was supported by [User Rights](https://www.user-rights.org).
+
 ### Added
 
 - Add `convertSpacesToStandard` built-in filter that replaces Unicode space separators (non-breaking space, narrow no-break space, ...) with a regular space; see more in the [built-in filters documentation](https://docs.opentermsarchive.org/terms/reference/built-in-filters/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All changes that impact users of this module are documented in this file, in the
 
 ### Added
 
-- Add `normalizeWhitespace` built-in filter that replaces Unicode space separators (non-breaking space, narrow no-break space, ...) with a regular space; see more in the [built-in filters documentation](https://docs.opentermsarchive.org/terms/reference/built-in-filters/)
+- Add `convertSpacesToStandard` built-in filter that replaces Unicode space separators (non-breaking space, narrow no-break space, ...) with a regular space; see more in the [built-in filters documentation](https://docs.opentermsarchive.org/terms/reference/built-in-filters/)
 
 ## 15.0.0 - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All changes that impact users of this module are documented in this file, in the [Common Changelog](https://common-changelog.org) format with some additional specifications defined in the CONTRIBUTING file. This codebase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased [minor]
+
+### Added
+
+- Add `normalizeWhitespace` built-in filter that replaces Unicode space separators (non-breaking space, narrow no-break space, ...) with a regular space; see more in the [built-in filters documentation](https://docs.opentermsarchive.org/terms/reference/built-in-filters/)
+
 ## 15.0.0 - 2026-07-07
 
 > Development of this release was supported by the [NGI0 Commons Fund](https://nlnet.nl/project/Modular-OTA/), a fund established by [NLnet](https://nlnet.nl/) with financial support from the European Commission's [Next Generation Internet](https://www.ngi.eu) programme, under the aegis of DG CNECT under grant agreement N°101069594.

--- a/src/archivist/extract/exposedFilters.js
+++ b/src/archivist/extract/exposedFilters.js
@@ -26,3 +26,18 @@ export function removeQueryParams(webPageDOM, paramsToRemove = []) {
     }
   }
 }
+
+const SPACE_SEPARATORS = /\p{Zs}/gu;
+
+export function normalizeWhitespace(webPageDOM) {
+  const walker = webPageDOM.createTreeWalker(webPageDOM.body, webPageDOM.defaultView.NodeFilter.SHOW_TEXT);
+
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    const original = node.nodeValue;
+    const normalized = original.replace(SPACE_SEPARATORS, ' ');
+
+    if (normalized !== original) {
+      node.nodeValue = normalized;
+    }
+  }
+}

--- a/src/archivist/extract/exposedFilters.js
+++ b/src/archivist/extract/exposedFilters.js
@@ -29,7 +29,7 @@ export function removeQueryParams(webPageDOM, paramsToRemove = []) {
 
 const SPACE_SEPARATORS = /\p{Zs}/gu;
 
-export function normalizeWhitespace(webPageDOM) {
+export function convertSpacesToStandard(webPageDOM) {
   const walker = webPageDOM.createTreeWalker(webPageDOM.body, webPageDOM.defaultView.NodeFilter.SHOW_TEXT);
 
   for (let node = walker.nextNode(); node; node = walker.nextNode()) {

--- a/src/archivist/extract/exposedFilters.test.js
+++ b/src/archivist/extract/exposedFilters.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
 import createWebPageDOM from './dom.js';
-import { removeQueryParams } from './exposedFilters.js';
+import { normalizeWhitespace, removeQueryParams } from './exposedFilters.js';
 
 describe('exposedFilters', () => {
   let webPageDOM;
@@ -263,6 +263,48 @@ fetch(trackingUrl);
 
         expect(preElement.textContent).to.equal(originalPreContent);
       });
+    });
+  });
+
+  describe('#normalizeWhitespace', () => {
+    let element;
+
+    afterEach(() => {
+      element.remove();
+    });
+
+    it('replaces Unicode space separators with a regular space', () => {
+      element = webPageDOM.createElement('p');
+      element.textContent = 'a\u00A0b\u202Fc\u2009d\u3000e';
+      webPageDOM.body.appendChild(element);
+
+      normalizeWhitespace(webPageDOM);
+
+      expect(element.textContent).to.equal('a b c d e');
+    });
+
+    it('normalizes text across nested elements', () => {
+      element = webPageDOM.createElement('div');
+      element.innerHTML = '<span>first\u00A0part</span><span>second\u00A0part</span>';
+      webPageDOM.body.appendChild(element);
+
+      normalizeWhitespace(webPageDOM);
+
+      expect(element.textContent).to.equal('first partsecond part');
+    });
+
+    it('does not alter element attributes or URLs, only text content', () => {
+      const href = 'https://example.com/page?label=gen173__nr-1';
+
+      element = webPageDOM.createElement('a');
+      element.setAttribute('href', href);
+      element.textContent = 'read\u00A0the\u00A0policy';
+      webPageDOM.body.appendChild(element);
+
+      normalizeWhitespace(webPageDOM);
+
+      expect(element.getAttribute('href')).to.equal(href);
+      expect(element.textContent).to.equal('read the policy');
     });
   });
 });

--- a/src/archivist/extract/exposedFilters.test.js
+++ b/src/archivist/extract/exposedFilters.test.js
@@ -267,44 +267,50 @@ fetch(trackingUrl);
   });
 
   describe('#convertSpacesToStandard', () => {
-    let element;
+    describe('with Unicode space separators in text', () => {
+      let element;
 
-    afterEach(() => {
-      element.remove();
+      before(() => {
+        element = webPageDOM.createElement('p');
+        element.textContent = 'a\u00A0b\u202Fc\u2009d\u3000e';
+        webPageDOM.body.appendChild(element);
+
+        convertSpacesToStandard(webPageDOM);
+      });
+
+      after(() => {
+        element.remove();
+      });
+
+      it('replaces them with a regular space', () => {
+        expect(element.textContent).to.equal('a b c d e');
+      });
     });
 
-    it('replaces Unicode space separators with a regular space', () => {
-      element = webPageDOM.createElement('p');
-      element.textContent = 'a\u00A0b\u202Fc\u2009d\u3000e';
-      webPageDOM.body.appendChild(element);
+    describe('with Unicode space separators in an attribute', () => {
+      let element;
+      const className = 'label\u00A0primary';
 
-      convertSpacesToStandard(webPageDOM);
+      before(() => {
+        element = webPageDOM.createElement('a');
+        element.setAttribute('class', className);
+        element.textContent = 'read\u00A0the\u00A0policy';
+        webPageDOM.body.appendChild(element);
 
-      expect(element.textContent).to.equal('a b c d e');
-    });
+        convertSpacesToStandard(webPageDOM);
+      });
 
-    it('normalizes text across nested elements', () => {
-      element = webPageDOM.createElement('div');
-      element.innerHTML = '<span>first\u00A0part</span><span>second\u00A0part</span>';
-      webPageDOM.body.appendChild(element);
+      after(() => {
+        element.remove();
+      });
 
-      convertSpacesToStandard(webPageDOM);
+      it('leaves attribute values untouched', () => {
+        expect(element.getAttribute('class')).to.equal(className);
+      });
 
-      expect(element.textContent).to.equal('first partsecond part');
-    });
-
-    it('does not alter element attributes or URLs, only text content', () => {
-      const href = 'https://example.com/page?label=gen173__nr-1';
-
-      element = webPageDOM.createElement('a');
-      element.setAttribute('href', href);
-      element.textContent = 'read\u00A0the\u00A0policy';
-      webPageDOM.body.appendChild(element);
-
-      convertSpacesToStandard(webPageDOM);
-
-      expect(element.getAttribute('href')).to.equal(href);
-      expect(element.textContent).to.equal('read the policy');
+      it('replaces them in the text content', () => {
+        expect(element.textContent).to.equal('read the policy');
+      });
     });
   });
 });

--- a/src/archivist/extract/exposedFilters.test.js
+++ b/src/archivist/extract/exposedFilters.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
 import createWebPageDOM from './dom.js';
-import { normalizeWhitespace, removeQueryParams } from './exposedFilters.js';
+import { convertSpacesToStandard, removeQueryParams } from './exposedFilters.js';
 
 describe('exposedFilters', () => {
   let webPageDOM;
@@ -266,7 +266,7 @@ fetch(trackingUrl);
     });
   });
 
-  describe('#normalizeWhitespace', () => {
+  describe('#convertSpacesToStandard', () => {
     let element;
 
     afterEach(() => {
@@ -278,7 +278,7 @@ fetch(trackingUrl);
       element.textContent = 'a\u00A0b\u202Fc\u2009d\u3000e';
       webPageDOM.body.appendChild(element);
 
-      normalizeWhitespace(webPageDOM);
+      convertSpacesToStandard(webPageDOM);
 
       expect(element.textContent).to.equal('a b c d e');
     });
@@ -288,7 +288,7 @@ fetch(trackingUrl);
       element.innerHTML = '<span>first\u00A0part</span><span>second\u00A0part</span>';
       webPageDOM.body.appendChild(element);
 
-      normalizeWhitespace(webPageDOM);
+      convertSpacesToStandard(webPageDOM);
 
       expect(element.textContent).to.equal('first partsecond part');
     });
@@ -301,7 +301,7 @@ fetch(trackingUrl);
       element.textContent = 'read\u00A0the\u00A0policy';
       webPageDOM.body.appendChild(element);
 
-      normalizeWhitespace(webPageDOM);
+      convertSpacesToStandard(webPageDOM);
 
       expect(element.getAttribute('href')).to.equal(href);
       expect(element.textContent).to.equal('read the policy');

--- a/src/archivist/fetcher/fullDomFetcher.test.js
+++ b/src/archivist/fetcher/fullDomFetcher.test.js
@@ -79,7 +79,7 @@ describe('Full DOM Fetcher', function () {
   });
 
   describe('#fetch', () => {
-    const config = { navigationTimeout: 1000, waitForElementsTimeout: 1000, language: 'en' };
+    const config = { navigationTimeout: 5000, waitForElementsTimeout: 5000, language: 'en' };
 
     it('waits for dynamically injected elements to appear in the DOM', async () => {
       const result = await fetch(`http://127.0.0.1:${SERVER_PORT}/dynamic`, ['.dynamic'], config);

--- a/src/archivist/index.test.js
+++ b/src/archivist/index.test.js
@@ -35,7 +35,7 @@ function resetGitRepositories() {
 }
 
 describe('Archivist', function () {
-  this.timeout(10000);
+  this.timeout(30000);
 
   const SERVICE_A_ID = 'service·A';
   const SERVICE_A_TYPE = 'Terms of Service';

--- a/src/archivist/services/index.test.js
+++ b/src/archivist/services/index.test.js
@@ -431,7 +431,7 @@ describe('Services', () => {
         expect(secondSourceDocument.filters).to.be.an('array');
         expect(secondSourceDocument.filters).to.have.length(2);
         expect(secondSourceDocument.filters[0]).to.be.a('function');
-        expect(secondSourceDocument.filters[0].name).to.equal('removeQueryParams');
+        expect(secondSourceDocument.filters[0].name).to.equal(realFilterNames[0]);
         expect(secondSourceDocument.filters[1]).to.be.a('function');
         expect(secondSourceDocument.filters[1].name).to.equal('removePrintButton');
       });


### PR DESCRIPTION
Some documents use Unicode space separators (non-breaking space U+00A0, narrow no-break space U+202F, ideographic space U+3000, ...) instead of regular spaces. These characters are visually identical to a normal space but differ byte-for-byte, which produces blink when tracking terms.

This changeset adds a `normalizeWhitespace` built-in filter that replaces every Unicode space separator (`\p{Zs}`) with a regular space in the text nodes of the page. 