### PR TITLE
Remove tracking query parameters by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All changes that impact users of this module are documented in this file, in the
 
 ### Changed
 
-- Remove well-known tracking query parameters (`utm_*`, `fbclid`, `gclid`, ...) by default when the built-in `removeQueryParams` filter is declared without parameters; see the full list in the [built-in filters documentation](https://docs.opentermsarchive.org/terms/reference/built-in-filters/)
+- Remove well-known tracking query parameters (`utm_*`, `fbclid`, `gclid`, ...) by default when the built-in `removeQueryParams` filter is declared without parameters; see the [built-in filters documentation](https://docs.opentermsarchive.org/terms/reference/built-in-filters/)
 
 ## 15.1.0 - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All changes that impact users of this module are documented in this file, in the [Common Changelog](https://common-changelog.org) format with some additional specifications defined in the CONTRIBUTING file. This codebase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased [patch]
+
+> Development of this release was made on a volunteer basis by [be-student](https://github.com/be-student).
+
+### Changed
+
+- Remove well-known tracking query parameters by default with the built-in `removeQueryParams` filter
+
 ## 15.1.0 - 2026-07-13
 
 > Development of this release was supported by [User Rights](https://www.user-rights.org).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 All changes that impact users of this module are documented in this file, in the [Common Changelog](https://common-changelog.org) format with some additional specifications defined in the CONTRIBUTING file. This codebase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased [patch]
+## Unreleased [minor]
 
 > Development of this release was made on a volunteer basis by [be-student](https://github.com/be-student).
 
 ### Changed
 
-- Remove well-known tracking query parameters by default with the built-in `removeQueryParams` filter
+- Remove well-known tracking query parameters (`utm_*`, `fbclid`, `gclid`, ...) by default when the built-in `removeQueryParams` filter is declared without parameters; see the full list in the [built-in filters documentation](https://docs.opentermsarchive.org/terms/reference/built-in-filters/)
 
 ## 15.1.0 - 2026-07-13
 

--- a/src/archivist/extract/exposedFilters.js
+++ b/src/archivist/extract/exposedFilters.js
@@ -1,5 +1,40 @@
-export function removeQueryParams(webPageDOM, paramsToRemove = []) {
-  const normalizedParams = Array.isArray(paramsToRemove) ? paramsToRemove : [paramsToRemove];
+// PrivacyTests tracking-query set at dda473a462e5c37f9f2c8b2367fbc5f834796be4.
+// Keep explicit filter parameters authoritative; this list applies only when a
+// declaration enables removeQueryParams without configuration.
+const DEFAULT_TRACKING_QUERY_PARAMS = Object.freeze([
+  'fbclid',
+  'gclid',
+  'msclkid',
+  'mc_eid',
+  'dclid',
+  'oly_anon_id',
+  'oly_enc_id',
+  '_openstat',
+  'vero_conv',
+  'vero_id',
+  'wickedid',
+  'yclid',
+  '__s',
+  'rb_clickid',
+  's_cid',
+  'ml_subscriber',
+  'ml_subscriber_hash',
+  '_hsenc',
+  '__hssc',
+  '__hstc',
+  '__hsfp',
+  'hsCtaTracking',
+  'mkt_tok',
+]);
+
+export function removeQueryParams(webPageDOM, paramsToRemove) {
+  let normalizedParams = DEFAULT_TRACKING_QUERY_PARAMS;
+
+  if (Array.isArray(paramsToRemove)) {
+    normalizedParams = paramsToRemove;
+  } else if (typeof paramsToRemove === 'string') {
+    normalizedParams = [paramsToRemove];
+  }
 
   if (!normalizedParams.length) {
     return;

--- a/src/archivist/extract/exposedFilters.js
+++ b/src/archivist/extract/exposedFilters.js
@@ -27,14 +27,8 @@ const DEFAULT_TRACKING_QUERY_PARAMS = Object.freeze([
   'mkt_tok',
 ]);
 
-export function removeQueryParams(webPageDOM, paramsToRemove) {
-  let normalizedParams = DEFAULT_TRACKING_QUERY_PARAMS;
-
-  if (Array.isArray(paramsToRemove)) {
-    normalizedParams = paramsToRemove;
-  } else if (typeof paramsToRemove === 'string') {
-    normalizedParams = [paramsToRemove];
-  }
+export function removeQueryParams(webPageDOM, paramsToRemove = DEFAULT_TRACKING_QUERY_PARAMS) {
+  const normalizedParams = Array.isArray(paramsToRemove) ? paramsToRemove : [paramsToRemove];
 
   if (!normalizedParams.length) {
     return;

--- a/src/archivist/extract/exposedFilters.js
+++ b/src/archivist/extract/exposedFilters.js
@@ -1,8 +1,10 @@
-// PrivacyTests tracking-query set at dda473a462e5c37f9f2c8b2367fbc5f834796be4.
-// Keep explicit filter parameters authoritative; this list applies only when a
-// declaration enables removeQueryParams without configuration.
 const DEFAULT_TRACKING_QUERY_PARAMS = Object.freeze([
-  'fbclid',
+  'utm_source', // Campaign parameters, see https://en.wikipedia.org/wiki/UTM_parameters
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+  'fbclid', // Click and user identifiers, see https://github.com/privacytests/privacytests/blob/dda473a462e5c37f9f2c8b2367fbc5f834796be4/live/results.js#L31-L65
   'gclid',
   'msclkid',
   'mc_eid',

--- a/src/archivist/extract/exposedFilters.test.js
+++ b/src/archivist/extract/exposedFilters.test.js
@@ -51,39 +51,12 @@ describe('exposedFilters', () => {
       });
     });
 
-    describe('with default parameters', () => {
+    describe('without parameters', () => {
       let link;
-      const trackingParams = [
-        'fbclid',
-        'gclid',
-        'msclkid',
-        'mc_eid',
-        'dclid',
-        'oly_anon_id',
-        'oly_enc_id',
-        '_openstat',
-        'vero_conv',
-        'vero_id',
-        'wickedid',
-        'yclid',
-        '__s',
-        'rb_clickid',
-        's_cid',
-        'ml_subscriber',
-        'ml_subscriber_hash',
-        '_hsenc',
-        '__hssc',
-        '__hstc',
-        '__hsfp',
-        'hsCtaTracking',
-        'mkt_tok',
-      ];
 
       before(() => {
-        const query = [ ...trackingParams.map(param => `${param}=tracking`), 'keep=value' ].join('&');
-
         link = webPageDOM.createElement('a');
-        link.setAttribute('href', `https://example.com/page?${query}`);
+        link.setAttribute('href', 'https://example.com/page?utm_source=newsletter&utm_campaign=spring&fbclid=abc&gclid=def&mkt_tok=ghi&keep=value');
         webPageDOM.body.appendChild(link);
       });
 

--- a/src/archivist/extract/exposedFilters.test.js
+++ b/src/archivist/extract/exposedFilters.test.js
@@ -51,6 +51,53 @@ describe('exposedFilters', () => {
       });
     });
 
+    describe('with default parameters', () => {
+      let link;
+      const trackingParams = [
+        'fbclid',
+        'gclid',
+        'msclkid',
+        'mc_eid',
+        'dclid',
+        'oly_anon_id',
+        'oly_enc_id',
+        '_openstat',
+        'vero_conv',
+        'vero_id',
+        'wickedid',
+        'yclid',
+        '__s',
+        'rb_clickid',
+        's_cid',
+        'ml_subscriber',
+        'ml_subscriber_hash',
+        '_hsenc',
+        '__hssc',
+        '__hstc',
+        '__hsfp',
+        'hsCtaTracking',
+        'mkt_tok',
+      ];
+
+      before(() => {
+        const query = [ ...trackingParams.map(param => `${param}=tracking`), 'keep=value' ].join('&');
+
+        link = webPageDOM.createElement('a');
+        link.setAttribute('href', `https://example.com/page?${query}`);
+        webPageDOM.body.appendChild(link);
+      });
+
+      after(() => {
+        link.remove();
+      });
+
+      it('removes well-known tracking parameters', () => {
+        removeQueryParams(webPageDOM);
+
+        expect(link.getAttribute('href')).to.equal('https://example.com/page?keep=value');
+      });
+    });
+
     describe('with string parameter', () => {
       let link;
 

--- a/src/archivist/extract/filter.test.js
+++ b/src/archivist/extract/filter.test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import createWebPageDOM from './dom.js';
+import { removeQueryParams } from './exposedFilters.js';
 import filter from './filter.js';
 
 const delay = ms => new Promise(resolve => { setTimeout(resolve, ms); });
@@ -95,6 +96,19 @@ describe('Filter', () => {
         await filter(webPageDOM, sourceDocument);
 
         expect(webPageDOM.querySelector('.custom-content').innerHTML).to.equal('Async content');
+      });
+
+      it('applies built-in filter defaults when passed the filter context', async () => {
+        const link = webPageDOM.createElement('a');
+
+        link.setAttribute('href', 'https://example.com/page?fbclid=tracking&keep=value');
+        webPageDOM.body.appendChild(link);
+        sourceDocument.filters = [removeQueryParams];
+
+        await filter(webPageDOM, sourceDocument);
+
+        expect(link.getAttribute('href')).to.equal('https://example.com/page?keep=value');
+        link.remove();
       });
 
       it('throws error on filter failure', async () => {

--- a/src/archivist/extract/filter.test.js
+++ b/src/archivist/extract/filter.test.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 
 import createWebPageDOM from './dom.js';
-import { removeQueryParams } from './exposedFilters.js';
 import filter from './filter.js';
 
 const delay = ms => new Promise(resolve => { setTimeout(resolve, ms); });
@@ -96,19 +95,6 @@ describe('Filter', () => {
         await filter(webPageDOM, sourceDocument);
 
         expect(webPageDOM.querySelector('.custom-content').innerHTML).to.equal('Async content');
-      });
-
-      it('applies built-in filter defaults when passed the filter context', async () => {
-        const link = webPageDOM.createElement('a');
-
-        link.setAttribute('href', 'https://example.com/page?fbclid=tracking&keep=value');
-        webPageDOM.body.appendChild(link);
-        sourceDocument.filters = [removeQueryParams];
-
-        await filter(webPageDOM, sourceDocument);
-
-        expect(link.getAttribute('href')).to.equal('https://example.com/page?keep=value');
-        link.remove();
       });
 
       it('throws error on filter failure', async () => {

--- a/src/archivist/services/index.js
+++ b/src/archivist/services/index.js
@@ -106,7 +106,7 @@ function createWrappedFilter(baseFunction, filterName, filterParams) {
     return;
   }
 
-  if (filterParams) {
+  if (filterParams || exposedFilters[filterName]) { // Built-in filters always receive their parameters before the context, even when none are declared
     const wrappedFilter = (webPageDOM, context) => baseFunction(webPageDOM, filterParams, context);
 
     Object.defineProperty(wrappedFilter, 'name', { value: filterName });

--- a/src/archivist/services/index.test.js
+++ b/src/archivist/services/index.test.js
@@ -6,6 +6,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 
 import expectedServices from '../../../test/fixtures/services.js';
+import createWebPageDOM from '../extract/dom.js';
 import * as exposedFilters from '../extract/exposedFilters.js';
 
 import Service from './service.js';
@@ -272,7 +273,18 @@ describe('Services', () => {
       const filterName = filterNames[0];
       const result = getServiceFilters({}, [filterName]);
 
-      expect(result).to.deep.equal([exposedFilters[filterName]]);
+      expect(result).to.have.length(1);
+      expect(result[0]).to.be.a('function');
+      expect(result[0].name).to.equal(filterName);
+    });
+
+    it('calls exposedFilters with their default parameters when declared by string name', () => {
+      const webPageDOM = createWebPageDOM('<!DOCTYPE html><html><body><a href="https://example.com/page?fbclid=abc&keep=value"></a></body></html>', 'https://example.com');
+      const [removeQueryParams] = getServiceFilters({}, ['removeQueryParams']);
+
+      removeQueryParams(webPageDOM, { fetch: 'https://example.com', select: [], remove: [], filter: ['removeQueryParams'] });
+
+      expect(webPageDOM.querySelector('a').getAttribute('href')).to.equal('https://example.com/page?keep=value');
     });
 
     it('returns filters from serviceFilters by string name', () => {
@@ -371,7 +383,7 @@ describe('Services', () => {
         expect(sourceDocument.filters).to.be.an('array');
         expect(sourceDocument.filters).to.have.length(2);
         expect(sourceDocument.filters[0]).to.be.a('function');
-        expect(sourceDocument.filters[0]).to.equal(exposedFilters[realFilterNames[0]]);
+        expect(sourceDocument.filters[0].name).to.equal(realFilterNames[0]);
         expect(sourceDocument.filters[1]).to.be.a('function');
         expect(sourceDocument.filters[1].name).to.equal('removePrintButton');
       });


### PR DESCRIPTION
## Summary

- use the 23 current PrivacyTests tracking query parameters when `removeQueryParams` is enabled without configuration
- preserve explicit string, array, and empty-array configurations
- cover both direct filter behavior and the runtime filter-context path

Closes #1263

The default list is pinned to [`privacytests/privacytests@dda473a`](https://github.com/privacytests/privacytests/blob/dda473a462e5c37f9f2c8b2367fbc5f834796be4/live/results.js#L22-L68), so its provenance and update boundary are explicit.

## Validation

- Baseline: the new default-list regression failed because all 23 tracking parameters remained in the URL
- `npm run test:only -- src/archivist/fetcher/index.test.js src/archivist/extract/filter.test.js src/archivist/extract/exposedFilters.test.js` (65 passing)
- `npx eslint src/archivist/extract/exposedFilters.js src/archivist/extract/exposedFilters.test.js src/archivist/extract/filter.test.js`
- `git diff --check`
